### PR TITLE
JAXB and java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     </issueManagement>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.version>6.7</sonar.version>
         <sonar.pluginName>Crowd</sonar.pluginName>
         <sonar.pluginClass>org.sonar.plugins.crowd.CrowdPlugin</sonar.pluginClass>
@@ -91,6 +92,26 @@
             <artifactId>jcl-over-slf4j</artifactId>
             <version>1.7.25</version>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+        </dependency>
         <!-- unit tests -->
         <dependency>
             <groupId>org.sonarsource.sonarqube</groupId>
@@ -118,12 +139,13 @@
             <url>https://packages.atlassian.com/maven-public-legacy-local</url>
         </repository>
     </repositories>
-    
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>

--- a/src/main/java/org/sonar/plugins/crowd/CrowdGroupsProvider.java
+++ b/src/main/java/org/sonar/plugins/crowd/CrowdGroupsProvider.java
@@ -60,7 +60,17 @@ public class CrowdGroupsProvider extends ExternalGroupsProvider {
   private Collection<String> getGroupsForUser(String username, int start, int pageSize)
     throws UserNotFoundException, OperationFailedException, InvalidAuthenticationException,
     ApplicationPermissionException {
-    return transform(crowdClient.getGroupsForNestedUser(username, start, pageSize), GROUP_TO_STRING);
+    // Had to add that as from "not really a good idea" in
+    // https://stackoverflow.com/questions/51518781/jaxb-not-available-on-tomcat-9-and-java-9-10
+    ClassLoader threadClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      // This will enforce the crowClient to use the plugin classloader
+      Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+      return transform(crowdClient.getGroupsForNestedUser(username, start, pageSize), GROUP_TO_STRING);
+    } finally {
+      // Bring back the original class loader for the thread
+      Thread.currentThread().setContextClassLoader(threadClassLoader);
+    }
   }
 
   private List<String> getGroupsForUser(String username)


### PR DESCRIPTION
fixes #25
Added `javax.xml.bind:jaxb-api:2.3.0`, `javax.activation:activation:1.1`, `com.sun.xml.bind:jaxb-core:2.3.0` and `org.glassfish.jaxb:jaxb-runtime:2.3.0` dependencies.
Forced the thread context loader (use when authenticating) to use the plugin context loader.

**NOTE**: I did not update the plugin version number in this PR