### PR TITLE
JAXB and java 11 (using aop)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     </issueManagement>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.version>6.7</sonar.version>
         <sonar.pluginName>Crowd</sonar.pluginName>
         <sonar.pluginClass>org.sonar.plugins.crowd.CrowdPlugin</sonar.pluginClass>
@@ -91,6 +92,26 @@
             <artifactId>jcl-over-slf4j</artifactId>
             <version>1.7.25</version>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+        </dependency>
         <!-- unit tests -->
         <dependency>
             <groupId>org.sonarsource.sonarqube</groupId>
@@ -107,8 +128,20 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
             <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.26</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+            <version>1.9.2</version>
         </dependency>
     </dependencies>
 
@@ -118,12 +151,13 @@
             <url>https://packages.atlassian.com/maven-public-legacy-local</url>
         </repository>
     </repositories>
-    
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
@@ -137,7 +171,25 @@
                 <configuration>
                     <pluginClass>${sonar.pluginClass}</pluginClass>
                 </configuration>
-          </plugin>
+            </plugin>
+            <plugin>
+                <groupId>com.nickwongdev</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.12.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <!-- MUST use 10, NOT 1.10 or ajc breaks -->
+                            <complianceLevel>8</complianceLevel>
+                            <source>8</source>
+                            <target>8</target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
       </build>
 </project>

--- a/src/main/java/org/sonar/plugins/crowd/ClassLoaderAspect.java
+++ b/src/main/java/org/sonar/plugins/crowd/ClassLoaderAspect.java
@@ -1,0 +1,43 @@
+package org.sonar.plugins.crowd;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This will wrap all the public methods from this package and enforce the current thread
+ * to use the class {@link ClassLoader} to execute the method before reverting back the
+ * thread {@link ClassLoader}.
+ * This is to add support for Java 11 where JAXB has been removed.
+ * Had to add that as from "not really a good idea" in
+ * https://stackoverflow.com/questions/51518781/jaxb-not-available-on-tomcat-9-and-java-9-10
+ */
+@Aspect
+public class ClassLoaderAspect {
+  private static final Logger LOG = LoggerFactory.getLogger(ClassLoaderAspect.class);
+
+  @Pointcut("execution(public * org.sonar.plugins.crowd.*.*(..))")
+  public void adjustClassLoader() {
+    //pointcut nothing to do
+  }
+
+  @Around("adjustClassLoader()")
+  public Object logging(ProceedingJoinPoint thisJoinPoint) throws Throwable {
+    final ClassLoader classClassLoader = this.getClass().getClassLoader();
+    LOG.debug("Uses class ClassLoader {} {}", thisJoinPoint.getSignature(), classClassLoader);
+    final ClassLoader threadClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      // This will enforce the crowClient to use the plugin classloader
+      Thread.currentThread().setContextClassLoader(classClassLoader);
+      return thisJoinPoint.proceed();
+    } finally {
+      // Bring back the original class loader for the thread
+      Thread.currentThread().setContextClassLoader(threadClassLoader);
+      LOG.debug("Uses thread ClassLoader {} {}", thisJoinPoint.getSignature(), threadClassLoader);
+    }
+  }
+}
+


### PR DESCRIPTION
fixes #25
Added `javax.xml.bind:jaxb-api:2.3.0`, `javax.activation:activation:1.1`, `com.sun.xml.bind:jaxb-core:2.3.0` and `org.glassfish.jaxb:jaxb-runtime:2.3.0` dependencies.
Forced the thread ClassLoader to use the class ClassLoader on all public methods in this package.
AOP weaving done at compile time by `aspectj-maven-plugin`.

This is an alternate way of wrapping all the public methods to set the right `ClassLoader`. The compilation of this plugin will work with Java 11 because it is using `com.nickwongdev:aspectj-maven-plugin:1.12.1` (see https://github.com/mojohaus/aspectj-maven-plugin/pull/45). This should be reverted to the official `org.codehaus.mojo:aspectj-maven-plugin` when the following issue is fixed: https://github.com/mojohaus/aspectj-maven-plugin/issues/41